### PR TITLE
Use Cake

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+     <add key="dotnetcore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />  
+     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview2-003121"
+    "version": "1.0.0-preview2-003133"
   }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.15.2" />
+	<package id="Cake" version="0.17.0" />
 </packages>


### PR DESCRIPTION
KoreBuildと比較
nupkg作成に向いている。

PowerShellによる実行になるが、
他、Linux用としても使いやすい。
MSBuildが出来るまではメインで使えそう。